### PR TITLE
Manual User activation

### DIFF
--- a/upload/system/controllers/activationneeded.php
+++ b/upload/system/controllers/activationneeded.php
@@ -1,0 +1,9 @@
+<?php
+	
+	$this->load_langfile('inside/global.php');
+
+	$D->page_title	= "Activation";
+
+	$this->load_template('activationneeded.php');
+	
+?>

--- a/upload/system/controllers/admin_activateusers.php
+++ b/upload/system/controllers/admin_activateusers.php
@@ -1,0 +1,60 @@
+<?php
+	
+	if( !$this->network->id ) {
+		$this->redirect('home');
+	}
+	if( !$this->user->is_logged ) {
+		$this->redirect('signin');
+	}
+	$db2->query('SELECT 1 FROM users WHERE id="'.$this->user->id.'" AND is_network_admin=1 LIMIT 1');
+	if( 0 == $db2->num_rows() ) {
+		$this->redirect('dashboard');
+	}
+	
+	$this->load_langfile('inside/global.php');
+	$this->load_langfile('inside/admin.php');
+	
+	$D->page_title	= $this->lang('admpgtitle_suspendusers', array('#SITE_TITLE#'=>$C->SITE_TITLE));
+	
+	$D->users	= array();
+	$r	= $db2->query('SELECT id FROM users WHERE active=2 ORDER BY fullname ASC, username ASC');
+	while($tmp = $db2->fetch_object($r)) {
+		if($sdf = $this->network->get_user_by_id($tmp->id)) {
+			$D->users[]	= $sdf;
+		}
+	}
+	
+	if( isset($_POST['admins']) ) {
+		$admins	= trim($_POST['admins']);
+		$admins	= trim($admins, ',');
+		$admins	= trim($admins);
+		$admins	= explode(',', $admins);
+		$ids	= array();
+		foreach($admins as $a) {
+			$a	= trim($a);
+			if( empty($a) ) { continue; }
+			$a	= $this->network->get_user_by_username($a);
+			if( ! $a ) { continue; }
+			$ids[]	= intval($a->id);
+		}
+		$ids	= array_unique($ids);
+		//$this->db2->query('UPDATE users SET active=1');
+		if( count($ids) ) {
+			// 				   UPDATE users SET active=1 WHERE id NOT IN(3,4) AND active=2;
+			$this->db2->query('UPDATE users SET active=1 WHERE id NOT IN('.implode(', ', $ids).') AND active=2 ');
+		}
+		foreach($ids as $a) {
+			$this->network->get_user_by_id($a, TRUE);
+		}
+		foreach($D->users as $sdf) {
+			if( in_array(intval($sdf->id), $ids) ) {
+				continue;
+			}
+			$this->network->get_user_by_id($sdf->id, TRUE);
+		}
+		$this->redirect( $C->SITE_URL.'admin/activateusers/msg:actisaved' );
+	}
+	
+	$this->load_template('admin_activateusers.php');
+	
+?>

--- a/upload/system/controllers/signup.php
+++ b/upload/system/controllers/signup.php
@@ -449,7 +449,7 @@
 				}
 			}
 		}
-		//
+		$this->load_template('signup-step2.php');
 	}
 	/* *************  END EMAIL VALIDATION ************* */
 

--- a/upload/system/controllers/signup.php
+++ b/upload/system/controllers/signup.php
@@ -183,12 +183,9 @@
 		$D->password2	= '';
 		$D->accept_terms	= FALSE;
 
-		if( ! isset($_POST['fullname'], $_POST['username']) ){
-			$this->load_template('signup-step2.php');
-		}
 
 		// This means the user has already filled in the name and username (and presumably password.)
-		else {
+		if( isset($_POST['fullname'], $_POST['username']) ) {
 			$D->submit	= TRUE;
 			$D->fullname	= trim($_POST['fullname']);
 			$D->fullname	= strip_tags($D->fullname);

--- a/upload/system/controllers/signup.php
+++ b/upload/system/controllers/signup.php
@@ -408,42 +408,43 @@
 						}
 					}
 				}
-				if( $D->network_members > 0 ) {
-					$key	= md5(time().rand(0,999999));
-					$_SESSION['reg_'.$key]	= (object) array (
-						'network_id'	=> $this->network->id,
-						'user_id'		=> $user_id,
-					);
+				// if( $D->network_members > 0 ) {
+				// 	$key	= md5(time().rand(0,999999));
+				// 	$_SESSION['reg_'.$key]	= (object) array (
+				// 		'network_id'	=> $this->network->id,
+				// 		'user_id'		=> $user_id,
+				// 	);
 					
-					$this->load_langfile('inside/notifications.php');
-					$this->load_langfile('email/notifications.php');
-					$r	= $db2->query('SELECT id FROM users WHERE active=1', FALSE);
-					while($sdf = $db2->fetch_object($r)) {
-						$uid	= intval($sdf->id);
-						$send_post	= FALSE;
-						$send_mail	= FALSE;
-						$n	= intval( $this->network->get_user_notif_rules($uid)->ntf_me_if_u_registers );
-						if( $n == 2 ) { $send_post = TRUE; } elseif( $n == 3 ) { $send_mail = TRUE; } elseif( $n == 1 ) { $send_post = TRUE; $send_mail = TRUE; }
-						if( $send_post ) {
-							$lng	= array('#COMPANY#'=>$C->COMPANY, '#USER#'=>'<a href="'.$C->SITE_URL.$this->user->info->username.'" title="'.htmlspecialchars($this->user->info->fullname).'"><span class="mpost_mentioned">@</span>'.$this->user->info->username.'</a>');
-							$this->network->send_notification_post($uid, 0, 'msg_ntf_me_if_u_registers', $lng, 'replace');
-						}
-						if( $send_mail ) {
-							$lng_txt	= array('#SITE_TITLE#'=>$C->SITE_TITLE, '#COMPANY#'=>$C->COMPANY, '#USER#'=>'@'.$this->user->info->username, '#NAME#'=>$this->user->info->fullname, '#A0#'=>$C->SITE_URL.$this->user->info->username);
-							$lng_htm	= array('#SITE_TITLE#'=>$C->SITE_TITLE, '#COMPANY#'=>$C->COMPANY, '#USER#'=>'<a href="'.$C->SITE_URL.$this->user->info->username.'" title="'.htmlspecialchars($this->user->info->fullname).'" target="_blank">@'.$this->user->info->username.'</a>', '#NAME#'=>$this->user->info->fullname, '#A0#'=>'');
-							$subject		= $this->lang('emlsubj_ntf_me_if_u_registers', $lng_txt);
-							$message_txt	= $this->lang('emltxt_ntf_me_if_u_registers', $lng_txt);
-							$message_htm	= $this->lang('emlhtml_ntf_me_if_u_registers', $lng_htm);
-							$this->network->send_notification_email($uid, 'u_edt_profl', $subject, $message_txt, $message_htm);
-						}
-					}
+				// 	$this->load_langfile('inside/notifications.php');
+				// 	$this->load_langfile('email/notifications.php');
+				// 	$r	= $db2->query('SELECT id FROM users WHERE active=1', FALSE);
+				// 	while($sdf = $db2->fetch_object($r)) {
+				// 		$uid	= intval($sdf->id);
+				// 		$send_post	= FALSE;
+				// 		$send_mail	= FALSE;
+				// 		$n	= intval( $this->network->get_user_notif_rules($uid)->ntf_me_if_u_registers );
+				// 		if( $n == 2 ) { $send_post = TRUE; } elseif( $n == 3 ) { $send_mail = TRUE; } elseif( $n == 1 ) { $send_post = TRUE; $send_mail = TRUE; }
+				// 		if( $send_post ) {
+				// 			$lng	= array('#COMPANY#'=>$C->COMPANY, '#USER#'=>'<a href="'.$C->SITE_URL.$this->user->info->username.'" title="'.htmlspecialchars($this->user->info->fullname).'"><span class="mpost_mentioned">@</span>'.$this->user->info->username.'</a>');
+				// 			$this->network->send_notification_post($uid, 0, 'msg_ntf_me_if_u_registers', $lng, 'replace');
+				// 		}
+				// 		if( $send_mail ) {
+				// 			$lng_txt	= array('#SITE_TITLE#'=>$C->SITE_TITLE, '#COMPANY#'=>$C->COMPANY, '#USER#'=>'@'.$this->user->info->username, '#NAME#'=>$this->user->info->fullname, '#A0#'=>$C->SITE_URL.$this->user->info->username);
+				// 			$lng_htm	= array('#SITE_TITLE#'=>$C->SITE_TITLE, '#COMPANY#'=>$C->COMPANY, '#USER#'=>'<a href="'.$C->SITE_URL.$this->user->info->username.'" title="'.htmlspecialchars($this->user->info->fullname).'" target="_blank">@'.$this->user->info->username.'</a>', '#NAME#'=>$this->user->info->fullname, '#A0#'=>'');
+				// 			$subject		= $this->lang('emlsubj_ntf_me_if_u_registers', $lng_txt);
+				// 			$message_txt	= $this->lang('emltxt_ntf_me_if_u_registers', $lng_txt);
+				// 			$message_htm	= $this->lang('emlhtml_ntf_me_if_u_registers', $lng_htm);
+				// 			$this->network->send_notification_email($uid, 'u_edt_profl', $subject, $message_txt, $message_htm);
+				// 		}
+				// 	}
 					
-					$this->redirect( $C->SITE_URL.'signup/follow/regid:'.$key);
-				}
-				else {
-					// everything worked out. redirect the user into his dashboard
-					$this->redirect($C->SITE_URL.'dashboard');
-				}
+				// 	$this->redirect( $C->SITE_URL.'signup/follow/regid:'.$key);
+				// }
+				// else {
+				// 	// everything worked out. redirect the user into his dashboard
+				// 	
+				// }
+				$this->redirect($C->SITE_URL.'activationneeded');
 			}
 		}
 		$this->load_template('signup-step2.php');

--- a/upload/themes/default/html/activationneeded.php
+++ b/upload/themes/default/html/activationneeded.php
@@ -1,0 +1,24 @@
+<?php
+		
+	$this->load_template('header.php');
+	
+?>	
+		<div id="pagebody" style="margin:0px; border-top:1px solid #fff;">
+			<div>		
+				<div class="ttl">
+					<div class="ttl2"><h3>Activation by an administrator</h3></div>
+				</div>
+				<div class="greygrad" style="margin-top:5px;">
+					<div class="greygrad2">
+						<div class="greygrad3">
+							A site-administrator now needs to unlock your account. Please be patient.
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+<?php
+	
+	$this->load_template('footer.php');
+	
+?>

--- a/upload/themes/default/html/admin_activateusers.php
+++ b/upload/themes/default/html/admin_activateusers.php
@@ -1,0 +1,62 @@
+<?php
+	
+	$this->load_template('header.php');
+	
+?>
+					<script type="text/javascript" src="<?= $C->SITE_URL.'themes/'.$C->THEME ?>/js/inside_admintools.js"></script>
+					<div id="settings">
+						<div id="settings_left">
+							<?php $this->load_template('admin_leftmenu.php') ?>
+						</div>
+						<div id="settings_right">
+							<div class="ttl">
+								<div class="ttl2">
+									<h3>Activate Users</h3>
+								</div>
+							</div>
+							<?php if( $this->param('msg')=='actisaved' ) { ?>
+							<?= okbox($this->lang('admsusp_frm_ok'), $this->lang('admsusp_frm_ok_txt'), TRUE, 'margin-top:5px; margin-bottom:4px;') ?>
+							<?php } ?>
+							<div class="greygrad" style="margin-top:5px;">
+								<div class="greygrad2">
+									<div class="greygrad3">
+										
+										<table id="setform" cellspacing="5" style="margin-top:5px;">
+											<tr>
+												<td width="150" class="setparam" valign="top" nowrap="nowrap">Users waiting for activation:</td>
+												<td width="400">
+													<div id="group_admins_list">
+														<div id="group_admins_link_empty_msg" class="yellowbox" style="border:0px solid; margin:0px;"><?= $this->lang('admsusp_frm_nobody') ?></div>
+													</div>
+												</td>
+											</tr>
+
+											<tr>
+												<td></td>
+												<td>
+													<form method="post" name="admform" action="<?= $C->SITE_URL ?>admin/suspendusers">
+														<input type="hidden" name="admins" value="" />
+														<input type="submit" value="<?= $this->lang('admsusp_frm_sbm') ?>" style="padding:4px; font-weight:bold;" />
+													</form>
+												</td>
+											</tr>
+										</table>
+									</div>
+								</div>
+							</div>
+							<script type="text/javascript">
+								jserr_add_admin_invalid_user	= "<?= $this->lang('admsusp_jserr_user1') ?>";
+								jsconfirm_admin_remove		= "";
+								js_group_membercheck	= false;
+								<?php foreach($D->users as $u) { ?>
+								group_admins_putintolist("<?= $u->username ?>");
+								<?php } ?>
+							</script>
+							
+						</div>
+					</div>
+<?php
+	
+	$this->load_template('footer.php');
+	
+?>

--- a/upload/themes/default/html/admin_leftmenu.php
+++ b/upload/themes/default/html/admin_leftmenu.php
@@ -8,4 +8,6 @@
 								<a href="<?= $C->SITE_URL ?>admin/administrators" class="<?= $this->request[1]=='administrators' ? 'onsidenav' : '' ?>"><?= $this->lang('admmenu_administrators') ?></a>
 								<a href="<?= $C->SITE_URL ?>admin/editusers" class="<?= $this->request[1]=='editusers' ? 'onsidenav' : '' ?>"><?= $this->lang('admmenu_editusers') ?></a>
 								<a href="<?= $C->SITE_URL ?>admin/suspendusers" class="<?= $this->request[1]=='suspendusers'||$this->request[1]=='deleteuser' ? 'onsidenav' : '' ?>"><?= $this->lang('admmenu_suspendusers') ?></a>
+								<a href="<?= $C->SITE_URL ?>admin/activateusers" class="<?= $this->request[1]=='activateusers' ? 'onsidenav' : '' ?>">Activate Users</a>
+
 							</div>


### PR DESCRIPTION
A user is now put in a sort of suspension on signup. It's not the same as a regular suspension though. This was done to be able to distinguish between new signups and suspended users.

Please try this and tell me what doesn't work. Things to be done are at the very least:
- proper localization (translation of new phrases into german and french?)
- send an email to an activated user (I couldn't find out how/where it's done when sending out the activation email.)
